### PR TITLE
Optimizer: Always Sort Gets

### DIFF
--- a/src/Optimizer.php
+++ b/src/Optimizer.php
@@ -24,12 +24,21 @@
 
 namespace Datto\Cinnabari;
 
+use Datto\Cinnabari\Optimizer\AlwaysSortGets;
 use Datto\Cinnabari\Optimizer\RemoveUnusedSorts;
 use Datto\Cinnabari\Optimizer\InsertDirectly;
 use Datto\Cinnabari\Optimizer\FilterBeforeSort;
+use Datto\Cinnabari\Schema;
 
 class Optimizer
 {
+    private $schema;
+
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
     public function optimize($request)
     {
         $request = $this->removeUnusedSorts($request);
@@ -60,7 +69,7 @@ class Optimizer
 
     private function alwaysSortGets($request)
     {
-        // Placeholder (for when this code is ready to release)
-        return $request;
+        $optimizer = new AlwaysSortGets($this->schema);
+        return $optimizer->optimize($request);
     }
 }

--- a/src/Optimizer/AlwaysSortGets.php
+++ b/src/Optimizer/AlwaysSortGets.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Copyright (C) 2016 Datto, Inc.
+ *
+ * This file is part of Cinnabari.
+ *
+ * Cinnabari is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * Cinnabari is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cinnabari. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Christopher Hoult <choult@datto.com>
+ * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL-3.0
+ * @copyright 2016 Datto, Inc.
+ */
+
+namespace Datto\Cinnabari\Optimizer;
+
+use Datto\Cinnabari\Parser;
+use Datto\Cinnabari\Schema;
+
+/**
+ * An optimizer to collapse sort, slice and filter functions when the request method is "insert"
+ *
+ * Rule: "insert(f(a, b), c) => insert(a, c)" when "f" is the "sort", "slice", or "filter" function
+ *   Note: this rule may apply more than once during the simplification of a request
+ *   Note: if this rule doesn't apply, then the request should be left unchanged
+*/
+class AlwaysSortGets
+{
+    private $schema;
+
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    public function optimize($request, $context = false)
+    {
+        switch ($request[0]) {
+            case Parser::TYPE_FUNCTION: {
+                // Optimize children
+                if (count($request) > 2) {
+                    for ($i = 2; $i < count($request); $i++) {
+                        $request[$i] = $this->optimizeChildren($request[$i]);
+                    }
+                }
+                // Optimize the get
+                if ($request[1] == 'get') {
+                    $request = $this->processGet($request);
+                }
+                break;
+            }
+            case Parser::TYPE_OBJECT: {
+                if (count($request) > 1) {
+                    for ($i = 1; $i < count($request); $i++) {
+                        $request[$i] = $this->optimizeChildren($request[$i]);
+                    }
+                }
+            }
+        }
+
+        return $request;
+    }
+
+    private function optimizeChildren(array $tokens)
+    {
+        foreach ($tokens as $idx => $subToken) {
+            $tokens[$idx] = $this->optimize($subToken);
+        }
+
+        return $tokens;
+    }
+
+    private function processGet($token)
+    {
+        // Is there a sort before the next get?
+        $functionList = $this->getFunctionNamesUntil('get', $token[2][0]);
+
+        if (\in_array('sort', $functionList)) {
+            return $token;
+        }
+
+        $primaryKey = $this->schema->getPrimaryKey($this->getListName($token));
+        if (!\in_array('slice', $functionList)) {
+            return $this->insertSort($token, $primaryKey);
+        }
+
+        return $this->insertSortAfter('slice', $token, $primaryKey);
+    }
+
+    private function insertSort($token, $primaryKey)
+    {
+        $lhs = $token[2];
+        $token[2] = array(
+            array(
+                Parser::TYPE_FUNCTION,
+                'sort',
+                $lhs,
+                array(array(Parser::TYPE_PROPERTY, $primaryKey))
+            )
+        );
+        return $token;
+    }
+
+    private function insertSortAfter($functionName, $token, $primaryKey)
+    {
+        if ($token[0] == Parser::TYPE_FUNCTION && $token[1] == $functionName) {
+            return $this->insertSort($token, $primaryKey);
+        }
+
+        $token[2][0] = $this->insertSortAfter($functionName, $token[2][0], $primaryKey);
+        return $token;
+    }
+
+    private function getFunctionNamesUntil($until, $token)
+    {
+        if ($token[0] !== Parser::TYPE_FUNCTION || $token[1] == $until) {
+            return array();
+        }
+
+        $ret = array();
+        if (isset($token[2][0])) {
+            $ret = $this->getFunctionNamesUntil($until, $token[2][0]);
+        }
+        \array_unshift($ret, $token[1]);
+        return $ret;
+    }
+
+    private function getListName($token)
+    {
+        return '';
+    }
+}

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * Copyright (C) 2016 Datto, Inc.
+ *
+ * This file is part of Cinnabari.
+ *
+ * Cinnabari is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * Cinnabari is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cinnabari. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Christopher Hoult <choult@datto.com>
+ * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL-3.0
+ * @copyright 2016 Datto, Inc.
+ */
+
+namespace Datto\Cinnabari;
+
+use \ArrayAccess;
+use \Iterator;
+
+/**
+ * A class to encapsulate the Cinnabari schema, and provide methods to process it
+ */
+class Schema implements ArrayAccess, Iterator
+{
+
+    const TYPE_BOOLEAN = 1;
+    const TYPE_INTEGER = 2;
+    const TYPE_STRING = 4;
+
+    /**
+     * @var array The raw schema data
+     */
+    private $data;
+
+    /**
+     * @var string The root class for the class tree
+     */
+    private $classRoot;
+
+    /**
+     * Constructs a new Schema object
+     *
+     * @param array $data       The raw schema as loaded from a schema file
+     * @param string $classRoot The root class for the class tree; defaults to 'Database'
+     */
+    public function __construct(array $data, $classRoot = 'Database')
+    {
+        $this->data = $data;
+        $this->classRoot = $classRoot;
+    }
+
+    /**
+     * Determines whether the passed property name (in dot-separated notation) exists
+     *
+     * @param string $propertyName
+     *
+     * @return bool
+     */
+    public function propertyExists($propertyName)
+    {
+        return ($this->getProperty($propertyName) !== null);
+    }
+
+    /**
+     * Gets the description for the passed property path (in dot-separated notation)
+     *
+     * @param string $path
+     * @param boolean $first    If set to true, the class root will be prepended to $path
+     *
+     * @return array|null
+     */
+    public function getProperty($path, $first = true)
+    {
+        $parts = \explode('.', $path);
+
+        if ($first) {
+            \array_unshift($parts, $this->classRoot);
+        }
+
+        // We always need a class name and a property name
+        if (count($parts) < 2) {
+            return null;
+        }
+
+        $className = $parts[0];
+        $propertyName = $parts[1];
+        $remainder = \array_slice($parts, 2);
+
+        if (!isset($this->data['classes'][$className], $this->data['classes'][$className][$propertyName])) {
+            return null;
+        }
+
+        $property = $this->data['classes'][$className][$propertyName];
+        $currentType = $property[0];
+        if (count($remainder)) {
+            if (\in_array($currentType, array(self::TYPE_BOOLEAN, self::TYPE_INTEGER, self::TYPE_STRING))) {
+                return null;
+            }
+
+            // Attach the referenced class to the front of the remaining path and recurse
+            \array_unshift($remainder, $currentType);
+            return $this->getProperty(\implode('.', $remainder), false);
+        }
+
+        return $property;
+    }
+
+    /**
+     * Gets the primary key for the passed list
+     *
+     * @param string $list
+     *
+     * @return string
+     */
+    public function getPrimaryKey($list)
+    {
+        return 'id';
+    }
+
+    /**
+     * Implementing methods for the various accessor interfaces
+     */
+
+    /**
+     * @inheritDoc
+     */
+    public function current()
+    {
+        return \current($this->data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function next()
+    {
+        return \next($this->data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function key()
+    {
+        return \key($this->data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function valid()
+    {
+        $keys = \array_keys($this->data);
+        $current = \key($this->data);
+        $last = end($keys);
+        return ($current !== end($keys));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function rewind()
+    {
+        \reset($this->data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetExists($offset)
+    {
+        return (\array_key_exists($offset, $this->data));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetGet($offset)
+    {
+        return ($this->offsetExists($offset)) ? $this->data[$offset] : null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+
+
+}

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -17,7 +17,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "~3.7",
+        "mockery/mockery": "~0.9"
     },
     "autoload": {
         "psr-4": {

--- a/tests/src/OptimizerTest.php
+++ b/tests/src/OptimizerTest.php
@@ -637,10 +637,82 @@ class OptimizerTest extends PHPUnit_Framework_TestCase
         $this->verify($input, $output);
     }
 
-    private function verify($input, $expectedOutput)
+    public function testGetAddsSort()
+    {
+        $input = array(Parser::TYPE_FUNCTION, 'get', array(
+            array(Parser::TYPE_FUNCTION, 'filter', array(
+                array(Parser::TYPE_PROPERTY, 'people'),
+                array(Parser::TYPE_FUNCTION, 'equal', array(
+                    array(Parser::TYPE_PROPERTY, 'age'),
+                    array(Parser::TYPE_PARAMETER, 'age')
+                ))
+            )),
+            array(Parser::TYPE_PROPERTY, 'id')
+        ));
+
+        $output = array(Parser::TYPE_FUNCTION, 'get', array(
+            array(Parser::TYPE_FUNCTION, 'sort', array(
+                array(Parser::TYPE_FUNCTION, 'filter', array(
+                    array(Parser::TYPE_PROPERTY, 'people'),
+                    array(Parser::TYPE_FUNCTION, 'equal', array(
+                        array(Parser::TYPE_PROPERTY, 'age'),
+                        array(Parser::TYPE_PARAMETER, 'age')
+                    ))
+                )),
+                array(Parser::TYPE_PROPERTY, 'personId')
+            )),
+            array(Parser::TYPE_PROPERTY, 'id')
+        ));
+
+        $this->verify($input, $output, 'people', 'personId');
+    }
+
+    public function testGetSliceAddsSort()
+    {
+        $input = array(Parser::TYPE_FUNCTION, 'get', array(
+            array(Parser::TYPE_FUNCTION, 'slice', array(
+                array(Parser::TYPE_FUNCTION, 'filter', array(
+                    array(Parser::TYPE_PROPERTY, 'people2'),
+                    array(Parser::TYPE_FUNCTION, 'equal', array(
+                        array(Parser::TYPE_PROPERTY, 'age'),
+                        array(Parser::TYPE_PARAMETER, 'age')
+                    ))
+                )),
+                array(Parser::TYPE_PARAMETER, ':begin'),
+                array(Parser::TYPE_PARAMETER, ':end')
+            )),
+            array(Parser::TYPE_PROPERTY, 'id')
+        ));
+
+        $output = array(Parser::TYPE_FUNCTION, 'get', array(
+            array(Parser::TYPE_FUNCTION, 'slice', array(
+                array(Parser::TYPE_FUNCTION, 'sort', array(
+                    array(Parser::TYPE_FUNCTION, 'filter', array(
+                        array(Parser::TYPE_PROPERTY, 'people2'),
+                        array(Parser::TYPE_FUNCTION, 'equal', array(
+                            array(Parser::TYPE_PROPERTY, 'age'),
+                            array(Parser::TYPE_PARAMETER, 'age')
+                        ))
+                    )),
+                    array(Parser::TYPE_PROPERTY, 'personId')
+                )),
+                array(Parser::TYPE_PARAMETER, ':begin'),
+                array(Parser::TYPE_PARAMETER, ':end'),
+            )),
+            array(Parser::TYPE_PROPERTY, 'id')
+        ));
+
+        $this->verify($input, $output, 'people2', 'personId');
+    }
+
+    private function verify($input, $expectedOutput, $listName = '', $idName = 'id')
     {
         $schema = \Mockery::mock('\Datto\Cinnabari\Schema');
-        $schema->shouldReceive('getPrimaryKey')->andReturn('id');
+        $mock = $schema->shouldReceive('getPrimaryKey');
+        if ($listName) {
+            $mock = $mock->with($listName);
+        }
+        $mock->andReturn($idName);
         $optimizer = new Optimizer($schema);
         $actualOutput = $optimizer->optimize($input);
 

--- a/tests/src/OptimizerTest.php
+++ b/tests/src/OptimizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Datto\Cinnabari\Tests;
 
+use Mockery;
 use Datto\Cinnabari\Optimizer;
 use Datto\Cinnabari\Parser;
 use PHPUnit_Framework_TestCase;
@@ -464,9 +465,7 @@ class OptimizerTest extends PHPUnit_Framework_TestCase
                     array(Parser::TYPE_PARAMETER, 'id')
                 ))
             )),
-            array(Parser::TYPE_OBJECT, array(
-                'id' => array(Parser::TYPE_PARAMETER, 'id')
-            ))
+            array(Parser::TYPE_PROPERTY, 'id')
         ));
 
         $output = array(Parser::TYPE_FUNCTION, 'insert', array(
@@ -477,9 +476,7 @@ class OptimizerTest extends PHPUnit_Framework_TestCase
                     array(Parser::TYPE_PARAMETER, 'id')
                 ))
             )),
-            array(Parser::TYPE_OBJECT, array(
-                'id' => array(Parser::TYPE_PARAMETER, 'id')
-            ))
+            array(Parser::TYPE_PROPERTY, 'id')
         ));
 
         $this->verify($input, $output);
@@ -642,7 +639,9 @@ class OptimizerTest extends PHPUnit_Framework_TestCase
 
     private function verify($input, $expectedOutput)
     {
-        $optimizer = new Optimizer();
+        $schema = \Mockery::mock('\Datto\Cinnabari\Schema');
+        $schema->shouldReceive('getPrimaryKey')->andReturn('id');
+        $optimizer = new Optimizer($schema);
         $actualOutput = $optimizer->optimize($input);
 
         $this->assertSame($expectedOutput, $actualOutput);

--- a/tests/src/SchemaTest.php
+++ b/tests/src/SchemaTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * Copyright (C) 2016 Datto, Inc.
+ *
+ * This file is part of Cinnabari.
+ *
+ * Cinnabari is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * Cinnabari is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cinnabari. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Christopher Hoult <choult@datto.com>
+ * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL-3.0
+ * @copyright 2016 Datto, Inc.
+ */
+
+namespace Datto\Cinnabari\Tests;
+
+use \Mockery;
+use Datto\Cinnabari\Schema;
+
+/**
+ * @coversDefaultClass \Datto\Cinnabari\Schema
+ */
+class SchemaTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * DataProvider for testGetProperty and testPropertyExists
+     *
+     * @return array
+     */
+    public function getPropertyProvider()
+    {
+        return array(
+            'Simple path' => array(
+                'data' => array(
+                    'classes' => array(
+                        'Database' => array(
+                            'clients' => array('Client', 'Clients')
+                        ),
+                        'Client' => array(
+                            'id' => array(Schema::TYPE_INTEGER, 'Id'),
+                            'name' => array(Schema::TYPE_STRING, 'Name')
+                        )
+                    )
+                ),
+                'propertyName' => 'clients.name',
+                'expected' => array(Schema::TYPE_STRING, 'Name')
+            ),
+            'Simple path 2' => array(
+                'data' => array(
+                    'classes' => array(
+                        'Database' => array(
+                            'clients' => array('Client', 'Clients')
+                        ),
+                        'Client' => array(
+                            'id' => array(Schema::TYPE_INTEGER, 'Id'),
+                            'name' => array(Schema::TYPE_STRING, 'Name')
+                        )
+                    )
+                ),
+                'propertyName' => 'clients.id',
+                'expected' => array(Schema::TYPE_INTEGER, 'Id'),
+            ),
+            'Deep path' => array(
+                'data' => array(
+                    'classes' => array(
+                        'Database' => array(
+                            'clients' => array('Client', 'Clients')
+                        ),
+                        'Client' => array(
+                            'id' => array(Schema::TYPE_INTEGER, 'Id'),
+                            'name' => array(Schema::TYPE_STRING, 'Name'),
+                            'reseller' => array('Reseller', 'Reseller'),
+                        ),
+                        'Reseller' => array(
+                            'name' => array(Schema::TYPE_STRING, 'Name')
+                        )
+                    )
+                ),
+                'propertyName' => 'clients.reseller.name',
+                'expected' => array(Schema::TYPE_STRING, 'Name')
+            ),
+            'Unknown path' => array(
+                'data' => array(
+                    'classes' => array(
+                        'Database' => array(
+                            'clients' => array('Client', 'Clients')
+                        ),
+                        'Client' => array(
+                            'id' => array(Schema::TYPE_INTEGER, 'Id'),
+                            'name' => array(Schema::TYPE_STRING, 'Name'),
+                            'reseller' => array('Reseller', 'Reseller'),
+                        ),
+                    )
+                ),
+                'propertyName' => 'clients.description',
+                'expected' => null
+            ),
+            'Unknown path, empty path' => array(
+                'data' => array(
+                    'classes' => array(
+                        'Database' => array(
+                            'clients' => array('Client', 'Clients')
+                        ),
+                        'Client' => array(
+                            'id' => array(Schema::TYPE_INTEGER, 'Id'),
+                            'name' => array(Schema::TYPE_STRING, 'Name'),
+                            'reseller' => array('Reseller', 'Reseller'),
+                        ),
+                    )
+                ),
+                'propertyName' => '',
+                'expected' => null
+            ),
+            'Unknown path, too long' => array(
+                'data' => array(
+                    'classes' => array(
+                        'Database' => array(
+                            'clients' => array('Client', 'Clients')
+                        ),
+                        'Client' => array(
+                            'id' => array(Schema::TYPE_INTEGER, 'Id'),
+                            'name' => array(Schema::TYPE_STRING, 'Name'),
+                            'reseller' => array('Reseller', 'Reseller'),
+                        ),
+                    )
+                ),
+                'propertyName' => 'clients.description.name',
+                'expected' => null
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getPropertyProvider
+     *
+     * @covers ::getProperty
+     *
+     * @param array $data
+     * @param string $propertyName
+     * @param mixed $expected
+     */
+    public function testGetProperty(array $data, $propertyName, $expected)
+    {
+        $schema = new Schema($data);
+        $this->assertEquals($expected, $schema->getProperty($propertyName));
+    }
+
+    /**
+     * @dataProvider getPropertyProvider
+     *
+     * @covers ::propertyExists
+     *
+     * @param array $data
+     * @param string $propertyName
+     * @param mixed $expected
+     */
+    public function testPropertyExists(array $data, $propertyName, $expected)
+    {
+        $schema = new Schema($data);
+        $this->assertEquals(($expected !== null), $schema->propertyExists($propertyName));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::offsetExists
+     * @covers ::offsetGet
+     * @covers ::offsetSet
+     * @covers ::offsetUnset
+     */
+    public function testArrayAccess()
+    {
+        $data = array(
+            'test' => array(1, 2, 3),
+            'value' => null,
+            'one more' => 'five'
+        );
+
+        $schema = new Schema($data);
+
+        foreach ($data as $key => $value) {
+            $this->assertEquals($value, $schema[$key]);
+        }
+
+        unset($schema['test']);
+        unset($data['test']);
+
+        foreach ($data as $key => $value) {
+            $this->assertEquals($value, $schema[$key]);
+        }
+
+        $schema['test 2'] = 'tested';
+        $data['test 2'] = 'tested';
+        foreach ($data as $key => $value) {
+            $this->assertEquals($value, $schema[$key]);
+        }
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::current
+     * @covers ::next
+     * @covers ::key
+     * @covers ::valid
+     * @covers ::rewind
+     */
+    public function testIterator()
+    {
+        $data = array(
+            'test' => array(1, 2, 3),
+            'value' => null,
+            'one more' => 'five'
+        );
+
+        $schema = new Schema($data);
+
+        foreach ($schema as $key => $value) {
+            $this->assertEquals($value, $data[$key]);
+        }
+    }
+}


### PR DESCRIPTION
This PR covers the AlwaysSortGets Optimizer, which attempts to insert a `sort` function where missing in the initial request.

The new `Schema` class is currently unable to determine the primary key for a list, so it's hard-coded to return `id` for the moment, but the Optimizer itself uses the response as expected.